### PR TITLE
updates for purescript 0.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,18 @@ Then delete everything in the file `src/Main.purs` and paste this into it:
 module Main where
 
 import Prelude
-import Control.Monad.Eff (Eff)
-import DOM (DOM)
-import DOM.HTML (window) as HTML
-import DOM.HTML.Window (document) as HTML
-import DOM.HTML.Types (htmlDocumentToNonElementParentNode) as HTML
-import DOM.Node.NonElementParentNode (getElementById) as DOM
-import DOM.Node.Types (ElementId(..), Element)
+import Effect (Effect)
+import Web.DOM (DOM, ElementId(..), Element)
+import Web.HTML (window) as HTML
+import Web.HTML.Window (document) as HTML
+import Web.HTML.HTMLDocument (toNonElementParentNode) as HTML
+import Web.DOM.NonElementParentNode (getElementById) as DOM
 import Data.Maybe (Maybe(..))
 import GMaps.LatLng (newLatLng)
 import GMaps.Map (gMap)
 import GMaps.MapOptions (MapOptions(..))
 
-loadMap :: forall eff.
-  Eff (dom :: DOM | eff)
-  Unit
+loadMap :: Effect Unit
 loadMap = do
   let eid = ElementId "map"
   latlng <- newLatLng (-25.363) (131.044)
@@ -47,17 +44,11 @@ loadMap = do
       pure unit
     Nothing -> pure unit
 
-getElementById' :: forall eff.
-  ElementId
-  -> Eff
-       ( dom :: DOM
-       | eff
-       )
-       (Maybe Element)
+getElementById' :: ElementId -> Effect (Maybe Element)
 getElementById' eid = do
   document <- HTML.document =<< HTML.window
-  elem <- DOM.getElementById eid (HTML.htmlDocumentToNonElementParentNode document)
-  DOM.getElementById eid (HTML.htmlDocumentToNonElementParentNode document)
+  elem <- DOM.getElementById eid (HTML.toNonElementParentNode document)
+  DOM.getElementById eid (HTML.toNonElementParentNode document)
 ```
 
 Create a new file (in the `map-project` directory), call it `index.html`

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-googlemaps",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "ignore": [
     "**/.*",
     "node_modules",
@@ -8,7 +8,7 @@
     "output"
   ],
   "dependencies": {
-    "purescript-dom": "^4.15.0",
-    "purescript-functions": "^3.0.0"
+    "purescript-web-dom": "^1.0.0",
+    "purescript-functions": "^4.0.0"
   }
 }

--- a/src/InfoWindow.purs
+++ b/src/InfoWindow.purs
@@ -1,7 +1,7 @@
 module GMaps.InfoWindow where
 
 import Prelude (Unit)
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import GMaps.Map (Map)
 import GMaps.Marker (Marker)
 import Data.Function.Uncurried (Fn1, runFn1, Fn3, runFn3)
@@ -17,12 +17,12 @@ type InfoWindowOptionsR = { content :: String }
 runInfoWindowOptions :: InfoWindowOptions -> InfoWindowOptionsR
 runInfoWindowOptions (InfoWindowOptions o) = { content: o.content }
 
-foreign import newInfoWindowImpl :: forall eff. Fn1 InfoWindowOptionsR (Eff eff InfoWindow)
+foreign import newInfoWindowImpl :: Fn1 InfoWindowOptionsR (Effect InfoWindow)
 
-newInfoWindow :: forall eff. InfoWindowOptionsR -> Eff eff InfoWindow
+newInfoWindow :: InfoWindowOptionsR -> Effect InfoWindow
 newInfoWindow = runFn1 newInfoWindowImpl
 
-foreign import openInfoWindowImpl :: forall eff. Fn3 InfoWindow Map Marker (Eff eff Unit)
+foreign import openInfoWindowImpl :: Fn3 InfoWindow Map Marker (Effect Unit)
 
-openInfoWindow :: forall eff. InfoWindow -> Map -> Marker -> (Eff eff Unit)
+openInfoWindow :: InfoWindow -> Map -> Marker -> Effect Unit
 openInfoWindow = runFn3 openInfoWindowImpl

--- a/src/LatLng.purs
+++ b/src/LatLng.purs
@@ -1,11 +1,11 @@
 module GMaps.LatLng where
 
-import Control.Monad.Eff
 import Data.Function.Uncurried (Fn2, runFn2)
+import Effect (Effect)
 
 data LatLng
 
-foreign import newLatLngImpl :: forall eff. Fn2 Number Number (Eff eff LatLng)
+foreign import newLatLngImpl :: Fn2 Number Number (Effect LatLng)
 
-newLatLng :: forall eff. Number -> Number -> Eff eff LatLng
+newLatLng :: Number -> Number -> Effect LatLng
 newLatLng = runFn2 newLatLngImpl

--- a/src/MVCArray.purs
+++ b/src/MVCArray.purs
@@ -1,7 +1,7 @@
 module GMaps.MVCArray where
 
 import Prelude (Unit)
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Data.Function.Uncurried (Fn0, runFn0, Fn1, runFn1, Fn2, runFn2)
 
 -- NOTE: This is different than upstream because we force all elements of the
@@ -9,17 +9,17 @@ import Data.Function.Uncurried (Fn0, runFn0, Fn1, runFn1, Fn2, runFn2)
 -- cost of some extra type safety, even though this is all wrapped in Eff. -rbe
 foreign import data MVCArray :: Type -> Type
 
-foreign import newMVCArrayImpl :: forall eff a. Fn0 (Eff eff (MVCArray a))
+foreign import newMVCArrayImpl :: forall a. Fn0 (Effect (MVCArray a))
 
-newMVCArray :: forall eff a. Eff eff (MVCArray a)
+newMVCArray :: forall a. Effect (MVCArray a)
 newMVCArray = runFn0 newMVCArrayImpl
 
-foreign import pushMVCArrayImpl :: forall eff a. Fn2 (MVCArray a) a (Eff eff Unit)
+foreign import pushMVCArrayImpl :: forall a. Fn2 (MVCArray a) a (Effect Unit)
 
-pushMVCArray :: forall a eff. MVCArray a -> a -> Eff eff Unit
+pushMVCArray :: forall a. MVCArray a -> a -> Effect Unit
 pushMVCArray = runFn2 pushMVCArrayImpl
 
-foreign import popMVCArrayImpl :: forall eff a. Fn1 (MVCArray a) (Eff eff a)
+foreign import popMVCArrayImpl :: forall a. Fn1 (MVCArray a) (Effect a)
 
-popMVCArray :: forall a eff. MVCArray a -> Eff eff a
+popMVCArray :: forall a. MVCArray a -> Effect a
 popMVCArray = runFn1 popMVCArrayImpl

--- a/src/Map.purs
+++ b/src/Map.purs
@@ -1,7 +1,7 @@
 module GMaps.Map (Map (), gMap, panTo) where
 
 import Prelude (Unit)
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Web.DOM (Element)
 import GMaps.LatLng (LatLng)
 import GMaps.MapOptions (MapOptions, runMapOptions)
@@ -9,15 +9,15 @@ import Data.Function.Uncurried (Fn2, runFn2)
 
 foreign import data Map :: Type
 
-foreign import gMapImpl :: forall eff. Fn2 Element { zoom :: Number, center :: LatLng, mapTypeId :: String } (Eff eff Map)
+foreign import gMapImpl :: Fn2 Element { zoom :: Number, center :: LatLng, mapTypeId :: String } (Effect Map)
 
-gMapFFI :: forall eff. Element -> { zoom :: Number, center :: LatLng, mapTypeId :: String } -> Eff eff Map
+gMapFFI :: Element -> { zoom :: Number, center :: LatLng, mapTypeId :: String } -> Effect Map
 gMapFFI = runFn2 gMapImpl
 
-gMap :: forall eff. Element -> MapOptions -> Eff eff Map
+gMap :: Element -> MapOptions -> Effect Map
 gMap e m = gMapFFI e (runMapOptions m)
 
-foreign import panToImpl :: forall eff. Fn2 Map LatLng (Eff eff Unit)
+foreign import panToImpl :: Fn2 Map LatLng (Effect Unit)
 
-panTo :: forall eff. Map -> LatLng -> Eff eff Unit
+panTo :: Map -> LatLng -> Effect Unit
 panTo = runFn2 panToImpl

--- a/src/Map.purs
+++ b/src/Map.purs
@@ -2,7 +2,7 @@ module GMaps.Map (Map (), gMap, panTo) where
 
 import Prelude (Unit)
 import Control.Monad.Eff (Eff)
-import DOM.Node.Types (Element)
+import Web.DOM (Element)
 import GMaps.LatLng (LatLng)
 import GMaps.MapOptions (MapOptions, runMapOptions)
 import Data.Function.Uncurried (Fn2, runFn2)

--- a/src/Marker.purs
+++ b/src/Marker.purs
@@ -1,7 +1,7 @@
 module GMaps.Marker where
 
 import Prelude (Unit)
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import Data.Maybe (Maybe, fromMaybe)
 import GMaps.LatLng (LatLng)
 import GMaps.Map (Map)
@@ -32,15 +32,15 @@ runMarkerOptions (MarkerOptions o) = { position: o.position
                                      , icon: fromMaybe undefined o.icon
                                      }
 
-foreign import newMarkerImpl :: forall eff. Fn1 MarkerOptionsR (Eff eff Marker)
+foreign import newMarkerImpl :: Fn1 MarkerOptionsR (Effect Marker)
 
-newMarkerFFI :: forall eff. MarkerOptionsR -> Eff eff Marker
+newMarkerFFI :: MarkerOptionsR -> Effect Marker
 newMarkerFFI = runFn1 newMarkerImpl
 
-newMarker :: forall eff. MarkerOptions -> Eff eff Marker
+newMarker :: MarkerOptions -> Effect Marker
 newMarker opts = newMarkerFFI (runMarkerOptions opts)
 
-foreign import setMarkerPositionImpl :: forall eff. Fn2 Marker LatLng (Eff eff Unit)
+foreign import setMarkerPositionImpl :: Fn2 Marker LatLng (Effect Unit)
 
-setMarkerPosition :: forall eff. Marker -> LatLng -> Eff eff Unit
+setMarkerPosition :: Marker -> LatLng -> Effect Unit
 setMarkerPosition = runFn2 setMarkerPositionImpl

--- a/src/Polyline.purs
+++ b/src/Polyline.purs
@@ -5,7 +5,7 @@ module GMaps.Polyline
   , setPolylinePath) where
 
 import Prelude (Unit)
-import Control.Monad.Eff (Eff)
+import Effect (Effect)
 import GMaps.LatLng (LatLng)
 import GMaps.Map (Map)
 import GMaps.MVCArray (MVCArray)
@@ -36,15 +36,15 @@ runPolylineOptions (PolylineOptions o) = { geodescic: o.geodescic
                                          , map: o.map
                                          }
 
-foreign import newPolylineImpl :: forall eff. Fn1 PolylineOptionsR (Eff eff Polyline)
+foreign import newPolylineImpl :: Fn1 PolylineOptionsR (Effect Polyline)
 
-newPolylineFFI :: forall eff. PolylineOptionsR -> Eff eff Polyline
+newPolylineFFI :: PolylineOptionsR -> Effect Polyline
 newPolylineFFI = runFn1 newPolylineImpl
 
-newPolyline :: forall eff. PolylineOptions -> Eff eff Polyline
+newPolyline :: PolylineOptions -> Effect Polyline
 newPolyline o = newPolylineFFI (runPolylineOptions o)
 
-foreign import setPolylinePathImpl :: forall eff. Fn2 Polyline (MVCArray LatLng) (Eff eff Unit)
+foreign import setPolylinePathImpl :: Fn2 Polyline (MVCArray LatLng) (Effect Unit)
 
-setPolylinePath :: forall eff. Polyline -> MVCArray LatLng -> Eff eff Unit
+setPolylinePath :: Polyline -> MVCArray LatLng -> Effect Unit
 setPolylinePath = runFn2 setPolylinePathImpl


### PR DESCRIPTION
- Replace the deprecated `purescript-dom` package for `purescript-web-dom`, which mostly resulted in only import changes.
- Replaced `purescript-eff` with `purescript-effect` which removed all the `forall eff.` types.

I can't guarantee the the updated example in the README works.  I was just eyeballing it off pursuit.